### PR TITLE
CF-6623 CF-6624 Replace MD5 with SHA-256 to fix CWE-327 weak crypto

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -1,7 +1,7 @@
 package gofpdf
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -26,16 +26,12 @@ type Attachment struct {
 
 // return the hex encoded checksum of `data`
 func checksum(data []byte) string {
-	tmp := md5.Sum(data)
-	sl := make([]byte, len(tmp))
-	for i, v := range tmp {
-		sl[i] = v
-	}
-	return hex.EncodeToString(sl)
+	tmp := sha256.Sum256(data)
+	return hex.EncodeToString(tmp[:])
 }
 
 // Writes a compressed file like object as ``/EmbeddedFile``. Compressing is
-// done with deflate. Includes length, compressed length and MD5 checksum.
+// done with deflate. Includes length, compressed length and SHA-256 checksum.
 func (f *Fpdf) writeCompressedFileObject(content []byte) {
 	lenUncompressed := len(content)
 	sum := checksum(content)

--- a/protect.go
+++ b/protect.go
@@ -20,8 +20,14 @@
 package gofpdf
 
 import (
+	"crypto/md5" //nolint:gosec // MD5 is required by the PDF Standard Security Handler algorithm
+	// (ISO 32000-1 §7.6.3). This is a spec-mandated usage, not a
+	// general-purpose security choice. The Veracode CWE-327 finding for
+	// this file (CF-6624) must be mitigated at the Veracode platform level
+	// as "Mitigated by Design": the RC4+MD5 key derivation is defined by
+	// the PDF 1.x specification and cannot be replaced without breaking
+	// compatibility with all conforming PDF readers.
 	"crypto/rc4"
-	"crypto/sha256"
 	"encoding/binary"
 	"math/rand"
 )
@@ -60,13 +66,13 @@ func (p *protectType) objectKey(n uint32) []byte {
 	binary.LittleEndian.PutUint32(nbuf, n)
 	b = append(b, p.encryptionKey...)
 	b = append(b, nbuf[0], nbuf[1], nbuf[2], 0, 0)
-	s := sha256.Sum256(b)
+	s := md5.Sum(b) //nolint:gosec // spec-mandated: ISO 32000-1 §7.6.3.3 Algorithm 1
 	return s[0:10]
 }
 
 func oValueGen(userPass, ownerPass []byte) (v []byte) {
 	var c *rc4.Cipher
-	tmp := sha256.Sum256(ownerPass)
+	tmp := md5.Sum(ownerPass) //nolint:gosec // spec-mandated: ISO 32000-1 §7.6.3.4 Algorithm 3 step (a)
 	c, _ = rc4.NewCipher(tmp[0:5])
 	size := len(userPass)
 	v = make([]byte, size, size)
@@ -107,7 +113,7 @@ func (p *protectType) setProtection(privFlag byte, userPassStr, ownerPassStr str
 	buf = append(buf, userPass...)
 	buf = append(buf, p.oValue...)
 	buf = append(buf, privFlag, 0xff, 0xff, 0xff)
-	sum := sha256.Sum256(buf)
+	sum := md5.Sum(buf) //nolint:gosec // spec-mandated: ISO 32000-1 §7.6.3.3 Algorithm 2 step (d)
 	p.encryptionKey = sum[0:5]
 	p.uValue = p.uValueGen()
 	p.pValue = -(int(privFlag^255) + 1)

--- a/protect.go
+++ b/protect.go
@@ -20,8 +20,8 @@
 package gofpdf
 
 import (
-	"crypto/md5"
 	"crypto/rc4"
+	"crypto/sha256"
 	"encoding/binary"
 	"math/rand"
 )
@@ -60,13 +60,13 @@ func (p *protectType) objectKey(n uint32) []byte {
 	binary.LittleEndian.PutUint32(nbuf, n)
 	b = append(b, p.encryptionKey...)
 	b = append(b, nbuf[0], nbuf[1], nbuf[2], 0, 0)
-	s := md5.Sum(b)
+	s := sha256.Sum256(b)
 	return s[0:10]
 }
 
 func oValueGen(userPass, ownerPass []byte) (v []byte) {
 	var c *rc4.Cipher
-	tmp := md5.Sum(ownerPass)
+	tmp := sha256.Sum256(ownerPass)
 	c, _ = rc4.NewCipher(tmp[0:5])
 	size := len(userPass)
 	v = make([]byte, size, size)
@@ -107,7 +107,7 @@ func (p *protectType) setProtection(privFlag byte, userPassStr, ownerPassStr str
 	buf = append(buf, userPass...)
 	buf = append(buf, p.oValue...)
 	buf = append(buf, privFlag, 0xff, 0xff, 0xff)
-	sum := md5.Sum(buf)
+	sum := sha256.Sum256(buf)
 	p.encryptionKey = sum[0:5]
 	p.uValue = p.uValueGen()
 	p.pValue = -(int(privFlag^255) + 1)


### PR DESCRIPTION
## Summary

### CF-6623 ✅ Code fix — `attachments.go`
Replace `crypto/md5` with `crypto/sha256` in the `checksum()` function used for PDF embedded file checksums. MD5 here is informational only (not spec-mandated), so SHA-256 is a clean drop-in replacement.

### CF-6624 ⚠️ Reverted — `protect.go` requires Veracode platform mitigation
The original fix replaced MD5 with SHA-256 in `protect.go`. **This was reverted** because `protect.go` implements the PDF Standard Security Handler (ISO 32000-1 §7.6.3), which mandates MD5 for key derivation in three specific algorithms:

| Function | Spec reference | Role |
|---|---|---|
| `setProtection` | ISO 32000-1 §7.6.3.3 Algorithm 2 step (d) | Derives the encryption key |
| `oValueGen` | ISO 32000-1 §7.6.3.4 Algorithm 3 step (a) | Derives the owner password value |
| `objectKey` | ISO 32000-1 §7.6.3.3 Algorithm 1 | Derives per-object encryption key |

Replacing MD5 with SHA-256 in any of these silently corrupts all password-protected PDFs — the decryption keys no longer match what any conforming PDF reader computes. The broken behavior would only surface at runtime when a reader fails to open an encrypted document.

**Resolution for CF-6624:** Mark as **"Mitigated by Design"** in Veracode with the justification:
> *MD5 usage in protect.go is mandated by ISO 32000-1 §7.6.3 (PDF Standard Security Handler). Replacing it breaks compatibility with all PDF readers. The full RC4+MD5 encryption scheme is inherently weak — the correct long-term fix is implementing AES-256 encryption per ISO 32000-2 (PDF 2.0), which is a separate scope of work.*

## Changes

| File | Change |
|---|---|
| `attachments.go` | `md5.Sum` → `sha256.Sum256` (CF-6623 code fix) |
| `protect.go` | Reverted to `md5` with `//nolint:gosec` + ISO 32000-1 spec citations (CF-6624 platform mitigation) |

## Test Plan
- [x] `go build ./...` passes